### PR TITLE
Fix slider getting in broken state

### DIFF
--- a/src/RangeSlider.svelte
+++ b/src/RangeSlider.svelte
@@ -70,7 +70,7 @@
     let perc = ((val - min) / (max - min)) * 100;
     if (perc >= 100) {
       return 100;
-    } else if (perc <= 0) {
+    } else if (perc <= 0 || isNaN(perc)) {
       return 0;
     } else {
       return parseFloat(perc.toFixed(precision));


### PR DESCRIPTION
Occurs when val === min and min === max. 

Can be reproduced in the `/tests/` page as follows:

1. Drag the first knob of the slider with values bound to the `dynamic` variable to meet the second knob (e.g. [50, 50])
2. Drag the first knob to a lower value (e.g. [40, 50])
3. Try to move the knob of the slider directly above.