### PR TITLE
Fix interaction on touch devices

### DIFF
--- a/src/RangeSlider.svelte
+++ b/src/RangeSlider.svelte
@@ -198,11 +198,11 @@
     let hPercent = 0;
     let hVal = 0;
     if (vertical) {
-      hPos = clientPos.y - dims.top;
+      hPos = clientPos.clientY - dims.top;
       hPercent = (hPos / dims.height) * 100;
       hVal = ((max - min) / 100) * hPercent + min;
     } else {
-      hPos = clientPos.x - dims.left;
+      hPos = clientPos.clientX - dims.left;
       hPercent = (hPos / dims.width) * 100;
       hVal = ((max - min) / 100) * hPercent + min;
     }
@@ -245,11 +245,11 @@
     let hPercent = 0;
     let hVal = 0;
     if (vertical) {
-      hPos = clientPos.y - dims.top;
+      hPos = clientPos.clientY - dims.top;
       hPercent = (hPos / dims.height) * 100;
       hVal = ((max - min) / 100) * hPercent + min;
     } else {
-      hPos = clientPos.x - dims.left;
+      hPos = clientPos.clientX - dims.left;
       hPercent = (hPos / dims.width) * 100;
       hVal = ((max - min) / 100) * hPercent + min;
     }


### PR DESCRIPTION
Bug was introduced by 9125b0cf026ef4f0c285bae13bf9fedfaf54a776.

The Touch interface does not have `x` and `y` properties like the
MouseEvent interface does, so NaNs were being created that caused
sliders to break upon touch interaction.

Documentation of interfaces:
https://developer.mozilla.org/en-US/docs/Web/API/Touch
https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent

Tested using simulated touch input in Firefox:
https://developer.mozilla.org/en-US/docs/Tools/Responsive_Design_Mode