### PR TITLE
Check whether trim/align changes values before reassigning

### DIFF
--- a/src/RangeSlider.svelte
+++ b/src/RangeSlider.svelte
@@ -59,7 +59,12 @@
 
   let springPositions;
 
-  const fixFloat = (v) => parseFloat(v.toFixed(precision));
+  /**
+   * make sure the value is coerced to a float value
+   * @param {number} v the value to fix
+   * @return {number} a float version of the input
+   **/
+  const fixFloat = (v) => parseFloat((+v).toFixed(precision));
 
   $: {
 
@@ -72,7 +77,7 @@
     // trim the range so it remains as a min/max (only 2 handles)
     // and also align the handles to the steps
     const trimmedAlignedValues = trimRange(values.map((v) => alignValueToStep(v)));
-    if ( !(values.length === trimmedAlignedValues.length) || !values.every((element, index) => element === trimmedAlignedValues[index]) ) {
+    if ( !(values.length === trimmedAlignedValues.length) || !values.every((element, index) => fixFloat(element) === trimmedAlignedValues[index]) ) {
       values = trimmedAlignedValues;
     }
 
@@ -132,12 +137,16 @@
    * @return {number} the value after it's been aligned
    **/
   $: alignValueToStep = function (val) {
+		
     // sanity check for performance
     if (val <= min) {
       return fixFloat(min);
     } else if (val >= max) {
       return fixFloat(max);
+    } else {
+      val = fixFloat(val);
     }
+		
     // find the middle-point between steps
     // and see if the value is closer to the
     // next step, or previous step

--- a/src/RangeSlider.svelte
+++ b/src/RangeSlider.svelte
@@ -71,7 +71,10 @@
     }
     // trim the range so it remains as a min/max (only 2 handles)
     // and also align the handles to the steps
-    values = trimRange(values.map((v) => alignValueToStep(v)));
+    const trimmedAlignedValues = trimRange(values.map((v) => alignValueToStep(v)));
+    if ( !(values.length === trimmedAlignedValues.length) || !values.every((element, index) => element === trimmedAlignedValues[index]) ) {
+      values = trimmedAlignedValues;
+    }
 
     // check if the valueLength (length of values[]) has changed,
     // because if so we need to re-seed the spring function with the

--- a/test/src/App.svelte
+++ b/test/src/App.svelte
@@ -1,6 +1,7 @@
 <script>
 
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
+  import { writable } from "svelte/store";
   import RangeSlider from "../../src/RangeSlider.svelte";
 
   let reversed = false;
@@ -59,6 +60,17 @@
 
   let decimals = [0.003, 0.123];
   let decimals2 = [-0.133, 0.444444444];
+
+  let value_store = writable({
+    first: [10, 20],
+    second: [30, 40]
+  });
+  let store_updates = 0;
+  const unsubscribe = value_store.subscribe(() => {
+    store_updates++;
+  })
+
+  onDestroy(unsubscribe);
 
 </script>
 
@@ -261,6 +273,11 @@
     <RangeSlider ariaLabels={["a", "b"]} values={[5,20]} {reversed} {hoverable} {disabled} />
     <RangeSlider ariaLabels={["a", "b"]} values={[5,20,40]} {reversed} {hoverable} {disabled} />
     <RangeSlider ariaLabels={["", "b"]} values={[5,20]} range {reversed} {hoverable} {disabled} />
+
+    <h2>Store updates</h2>
+    <RangeSlider bind:values={$value_store.first} {reversed} {hoverable} {disabled} />
+    <RangeSlider bind:values={$value_store.second} {reversed} {hoverable} {disabled} />
+    Number of store updates: {store_updates}<br>
 
   </div>
 


### PR DESCRIPTION
This PR fixes #116. I thought I would give this bug (if it is one) a shot immediately, even if the issue is still under consideration. No worries if the PR needs to be rejected for any reason.

Previously, the internal `values` of a `RangeSlider` would always be reactively reassigned during trimming/aligning when the bound store changes, even if `values` did not change during this process. This caused duplicate updates to the store dependent on the number of sliders bound to it.

In the proposed changes, `values` is only reassigned during the trimming/aligning process if its values are actually changed.

A few test sliders were added to show the number of store updates on slider change. With the implemented changes to the code, they behave as expected, causing a single update per change.