### PR TITLE
add a slot around the float to allow for finer grained control of handle

### DIFF
--- a/src/RangeSlider.svelte
+++ b/src/RangeSlider.svelte
@@ -840,9 +840,12 @@
     >
       <span class="rangeNub" />
       {#if float}
-        <span class="rangeFloat">
-          {#if prefix}<span class="rangeFloat-prefix">{prefix}</span>{/if}{handleFormatter(value,index,percentOf(value))}{#if suffix}<span class="rangeFloat-suffix">{suffix}</span>{/if}
-        </span>
+        {@const formattedValue = handleFormatter(value,index,percentOf(value))}
+        <slot name="float" value={formattedValue} prefix={prefix} suffix={suffix}>
+          <span class="rangeFloat">
+            {#if prefix}<span class="rangeFloat-prefix">{prefix}</span>{/if}{formattedValue}{#if suffix}<span class="rangeFloat-suffix">{suffix}</span>{/if}
+          </span>
+        </slot>
       {/if}
     </span>
   {/each}


### PR DESCRIPTION
Hello, I've created this PR as an exploration to solve a specific problem I'm running into.

My range float has a large amount of text which, on mobile, when the slider is nearly full width causes the rangeFloat span to exceed the boundaries of the viewport which in turn causes the screen to shrink unless pinch to zoom is disabled.

This PR is really intended so that in my codebase I can do something like:

```
<RangeSlider ...lotsOfOptions>
  <svelte:fragment slot="float" let:value>
    <span class="sm:hidden">${value}</span>
  </svelte:fragment>
</RangeSlider>
```

In my example above display:none would be present on the mobile breakpoint preventing the overflow situation.

Let me know what you think @simeydotme ?