### PR TITLE
fix: add `exports` field to package.json for Svelte entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "svelte-range-slider-pips",
   "version": "2.3.0",
   "svelte": "src/index.js",
+  "exports": {
+    ".": {
+      "svelte": "./src/index.js"
+    }
+  },
   "module": "dist/svelte-range-slider-pips.mjs",
   "main": "dist/svelte-range-slider-pips.js",
   "scripts": {


### PR DESCRIPTION
fix: https://github.com/simeydotme/svelte-range-slider-pips/issues/125

This fix should eliminate the annoying warnings.
```shell
11:10:13 [vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

svelte-range-slider-pips@2.3.0

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
```