### PR TITLE
fix doc links examples & recipes

### DIFF
--- a/src/content/docs/en/examples.mdx
+++ b/src/content/docs/en/examples.mdx
@@ -11,19 +11,19 @@ Use the links below to see examples of different options (props) available for t
 
 
 <RecipeList>
-  <Recipe name="Values & Binding" link="examples/values" />
-  <Recipe name="Min & Max" link="examples/min-max" />
-  <Recipe name="Pips" link="examples/pips" />
-  <Recipe name="Pip Labels" link="examples/pip-labels" />
-  <Recipe name="Steps" link="examples/steps" />
-  <Recipe name="Pip Steps" link="examples/pip-steps" />
-  <Recipe name="Steps & Pip Steps" link="examples/steps-combined" />
-  <Recipe name="Ranges" link="examples/range" />
-  <Recipe name="Pushy" link="examples/range#pushy-range-handles" />
-  <Recipe name="Float" link="examples/float" />
-  <Recipe name="Vertical" link="examples/vertical" />
-  <Recipe name="Prefix & Suffix" link="examples/prefix-suffix" />
-  <Recipe name="Formatter" link="examples/formatter" />
-  <Recipe name="Disabled" link="examples/disabled" />
-  <Recipe name="Easing" link="examples/easing" />
+  <Recipe name="Values & Binding" link="values" />
+  <Recipe name="Min & Max" link="min-max" />
+  <Recipe name="Pips" link="pips" />
+  <Recipe name="Pip Labels" link="pip-labels" />
+  <Recipe name="Steps" link="steps" />
+  <Recipe name="Pip Steps" link="pip-steps" />
+  <Recipe name="Steps & Pip Steps" link="steps-combined" />
+  <Recipe name="Ranges" link="range" />
+  <Recipe name="Pushy" link="range#pushy-range-handles" />
+  <Recipe name="Float" link="float" />
+  <Recipe name="Vertical" link="vertical" />
+  <Recipe name="Prefix & Suffix" link="prefix-suffix" />
+  <Recipe name="Formatter" link="formatter" />
+  <Recipe name="Disabled" link="disabled" />
+  <Recipe name="Easing" link="easing" />
 </RecipeList>

--- a/src/content/docs/en/recipes.mdx
+++ b/src/content/docs/en/recipes.mdx
@@ -14,9 +14,9 @@ demos with the code and css needed to make it work.
 
 
 <RecipeList>
-  <Recipe name="Color Picker UI" link="recipes/color-picker" image="color-ui" />
-  <Recipe name="Daisy UI" link="recipes/daisy-ui" image="daisy-ui" />
-  <Recipe name="Price Range" link="recipes/price-range" image="price-gradient" />
+  <Recipe name="Color Picker UI" link="color-picker" image="color-ui" />
+  <Recipe name="Daisy UI" link="daisy-ui" image="daisy-ui" />
+  <Recipe name="Price Range" link="price-range" image="price-gradient" />
 </RecipeList>
 
 #### More to come...


### PR DESCRIPTION
fixes #118 

hey, 
this will fix these behaviours

> 
> Examples:
> All 'Recipe' style links on the Examples page are broken, resulting in a 404.
> 
> Recipes:
> All 'Recipe' style links on the Recipes page are broken, resulting in a 404.
> The 'Recipe' style links have broken images.

This behaviour could i not reproduce
> Sidebar:
> Pips link within Options does not navigate to the pips prop in the article.
> Range link within Options does not navigate to the range prop in the article.

Links LGTM: 
https://simeydotme.github.io/svelte-range-slider-pips/en/options/#pips
https://simeydotme.github.io/svelte-range-slider-pips/en/options/#range

i guess the problem why the current behaviour works on dev server is how the astro dev server is handling the case that the example.mdx links to a file inside example/**.mdx