### PR TITLE
Mark RangeSlider as non-immutable

### DIFF
--- a/dist/range-slider-pips.js
+++ b/dist/range-slider-pips.js
@@ -2780,7 +2780,7 @@
 		return child_ctx;
 	}
 
-	// (564:6) {#if float}
+	// (566:6) {#if float}
 	function create_if_block_2(ctx) {
 		let span;
 		let if_block0_anchor;
@@ -2849,7 +2849,7 @@
 		};
 	}
 
-	// (568:10) {#if prefix}
+	// (570:10) {#if prefix}
 	function create_if_block_4(ctx) {
 		let span;
 		let t;
@@ -2875,7 +2875,7 @@
 		};
 	}
 
-	// (569:40) {#if suffix}
+	// (571:40) {#if suffix}
 	function create_if_block_3(ctx) {
 		let span;
 		let t;
@@ -2901,7 +2901,7 @@
 		};
 	}
 
-	// (541:2) {#each values as value, index}
+	// (543:2) {#each values as value, index}
 	function create_each_block(ctx) {
 		let span1;
 		let span0;
@@ -3037,7 +3037,7 @@
 		};
 	}
 
-	// (575:2) {#if range}
+	// (577:2) {#if range}
 	function create_if_block_1(ctx) {
 		let span;
 		let span_style_value;
@@ -3064,7 +3064,7 @@
 		};
 	}
 
-	// (582:2) {#if pips}
+	// (584:2) {#if pips}
 	function create_if_block(ctx) {
 		let rangepips;
 		let current;

--- a/dist/range-slider-pips.mjs
+++ b/dist/range-slider-pips.mjs
@@ -2774,7 +2774,7 @@ function get_if_ctx(ctx) {
 	return child_ctx;
 }
 
-// (564:6) {#if float}
+// (566:6) {#if float}
 function create_if_block_2(ctx) {
 	let span;
 	let if_block0_anchor;
@@ -2843,7 +2843,7 @@ function create_if_block_2(ctx) {
 	};
 }
 
-// (568:10) {#if prefix}
+// (570:10) {#if prefix}
 function create_if_block_4(ctx) {
 	let span;
 	let t;
@@ -2869,7 +2869,7 @@ function create_if_block_4(ctx) {
 	};
 }
 
-// (569:40) {#if suffix}
+// (571:40) {#if suffix}
 function create_if_block_3(ctx) {
 	let span;
 	let t;
@@ -2895,7 +2895,7 @@ function create_if_block_3(ctx) {
 	};
 }
 
-// (541:2) {#each values as value, index}
+// (543:2) {#each values as value, index}
 function create_each_block(ctx) {
 	let span1;
 	let span0;
@@ -3031,7 +3031,7 @@ function create_each_block(ctx) {
 	};
 }
 
-// (575:2) {#if range}
+// (577:2) {#if range}
 function create_if_block_1(ctx) {
 	let span;
 	let span_style_value;
@@ -3058,7 +3058,7 @@ function create_if_block_1(ctx) {
 	};
 }
 
-// (582:2) {#if pips}
+// (584:2) {#if pips}
 function create_if_block(ctx) {
 	let rangepips;
 	let current;

--- a/dist/svelte/components/RangeSlider.svelte
+++ b/dist/svelte/components/RangeSlider.svelte
@@ -1,3 +1,5 @@
+<svelte:options immutable={false} />
+
 <script>import { spring } from "svelte/motion";
 import { createEventDispatcher } from "svelte";
 import {

--- a/src/lib/components/RangeSlider.svelte
+++ b/src/lib/components/RangeSlider.svelte
@@ -1,3 +1,5 @@
+<svelte:options immutable={false} />
+
 <script lang="ts">
   import { type SpringOpts, type Spring, spring } from 'svelte/motion';
   import { createEventDispatcher } from 'svelte';


### PR DESCRIPTION
Hello, I've created this pull request for the related issue I've just opened [here](https://github.com/simeydotme/svelte-range-slider-pips/issues/146).

Since the 3.0.0 release, when svelte config has the immutable compiler flag enabled, the slider does not move or update.

**To Reproduce**

- Go to the bug reproduction here: [stackblitz](https://stackblitz.com/edit/vitejs-vite-rwfqjn?file=svelte.config.js)
- Try to interact with the slider (it does not move on click or drag)
- In `svelte.config.js` change the value of `immutable` to `false`, now it works as expected.

**Expected behavior**
The slider should update regardless of the immutable setting.

(Thanks @AXNLovesProlog for spotting the bug)