### PR TITLE
Fix component subpath exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
       },
       "./dist/range-slider-pips.css"
     ],
-    "./RangeSlider.svelte": "./src/lib/RangeSlider.svelte",
-    "./RangePips.svelte": "./src/lib/RangePips.svelte"
+    "./RangeSlider.svelte": "./src/lib/components/RangeSlider.svelte",
+    "./RangePips.svelte": "./src/lib/components/RangePips.svelte"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

- update `./RangeSlider.svelte` and `./RangePips.svelte` package exports to point at the component files that are actually included in the package
- keep the existing exported subpath names unchanged

The current package exports point at `./src/lib/RangeSlider.svelte` and `./src/lib/RangePips.svelte`, but those files are not present in the published package. The matching components are under `src/lib/components/`.

Reference: charles-openclaw/charles-microbounties#1177

## Validation

- `npm run lint`
- `npm pack --dry-run --json` and checked the tarball includes:
  - `src/lib/components/RangeSlider.svelte`
  - `src/lib/components/RangePips.svelte`
- packed-package clean install and verified package subpath resolution with `require.resolve()`:
  - `svelte-range-slider-pips/RangeSlider.svelte`
  - `svelte-range-slider-pips/RangePips.svelte`
- `git diff --check`
