### PR TITLE
Fix Svelte component export paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
       },
       "./dist/range-slider-pips.css"
     ],
-    "./RangeSlider.svelte": "./src/lib/RangeSlider.svelte",
-    "./RangePips.svelte": "./src/lib/RangePips.svelte"
+    "./RangeSlider.svelte": "./src/lib/components/RangeSlider.svelte",
+    "./RangePips.svelte": "./src/lib/components/RangePips.svelte"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Point exported component subpaths at the shipped src/lib/components files.